### PR TITLE
Xdoclint, changelog, findbugs version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- Change log.
+
+### Changed
+- Updated Findbugs plug-in to 3.0.4 from 2.5.3 as the earlier version was not compatible with Java 8.
+- Added profile to enable `-Xdoclint` to work around blocking Javadoc warnings in JDK versions since 1.8.
+
+## [1.1.1] - 2017-03-07
+### Added
+- Previous version, no changes recorded.

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <cobertura.version>2.0.3</cobertura.version>
     <cobertura.maven.plugin.version>2.6</cobertura.maven.plugin.version>
     <failsafe.maven.plugin.version>2.4.3-alpha-1</failsafe.maven.plugin.version>
-    <findbugs.maven.plugin.version>2.5.3</findbugs.maven.plugin.version>    
+    <findbugs.maven.plugin.version>3.0.4</findbugs.maven.plugin.version>    
     <hotels.oss.plugin.config.version>1.0.4</hotels.oss.plugin.config.version>
     <jdk.version>1.7</jdk.version>
     <license.maven.plugin.version>3.0</license.maven.plugin.version>
@@ -155,7 +155,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven.javadoc.plugin.version}</version>
         <configuration>
-          <encoding>UTF-8</encoding>
+          <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
         <executions>
           <execution>
@@ -310,6 +310,37 @@
     </pluginManagement>
   </build>
 
+  <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <reporting>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </reporting>
+    </profile>
+  </profiles>
+  
   <reporting>
     <plugins>
       <plugin>


### PR DESCRIPTION
I'm finding that I'm not able to release projects using this POM from platforms with a JDK version ≥ 1.8. This is largely due to the `javadoc` configuration. The version of Findbugs was also failing on 1.8.