### PR TITLE
Modified configuration in order to work with java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed `cobertura-maven-plugin`, from reporting sections, as it's not compatible with JDK versions greater than 1.8.
 - Updated `maven-compiler-plugin` version to 3.8.0 (was 3.7.0).
 - Updated `jacoco-maven-plugin` version to 0.8.2 (was 0.8.1).
-- Added `maven-compiler-plugin` option in order to add constructor parameter's names to compiled classes.
+- Added `maven-compiler-plugin` option in order to add constructor parameters' names to compiled classes.
 
 ## [2.3.5] - 2019-01-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.0.0] - TBD
 ### Changed
 - Updated `jdk` version to 1.8 (was 1.7).
-- Removed `cobertura-maven-plugin` as it's not compatible with jdk version grater than 1.8.
+- Removed `cobertura-maven-plugin` as it's not compatible with JDK versions greater than 1.7.
 - Updated `maven-compiler-plugin` version to 3.8.0 (was 3.7.0).
 - Updated `jacoco-maven-plugin` version to 0.8.2 (was 0.8.1).
 - Added `maven-compiler-plugin` option in order to add constructor parameter's names to compiled classes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.3.6] - 2019-01-24
+## [3.0.0] - TBD
 ### Changed
-- Modified `cobertura-maven-plugin` configuration in order to be not inherited by submodules.
-- Updated `jacoco-maven-plugin` version to 0.8.2 (was 0.8.1)..
-- Updated `maven-compiler-plugin` version to 3.8.0 (was 3.7.0)..
-- Added `maven-compiler-plugin` option in order to add constructor parameter's names to compiled classes.
 - Updated `jdk` version to 1.8 (was 1.7)..
+- Updated `maven-compiler-plugin` version to 3.8.0 (was 3.7.0).
+- Modified `cobertura-maven-plugin` configuration in order to be not inherited by submodules.
+- Updated `jacoco-maven-plugin` version to 0.8.2 (was 0.8.1).
+- Added `maven-compiler-plugin` option in order to add constructor parameter's names to compiled classes.
 
 ## [2.3.5] - 2019-01-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.3.6] - 2019-01-24
+### Changed
+- Modified `cobertura-maven-plugin` configuration in order to be not inherited by submodules.
+- Updated `jacoco-maven-plugin` version to 0.8.2 (was 0.8.1)..
+- Updated `maven-compiler-plugin` version to 3.8.0 (was 3.7.0)..
+- Added `maven-compiler-plugin` option in order to add constructor parameter's names to compiled classes.
+- Updated `jdk` version to 1.8 (was 1.7)..
+
 ## [2.3.5] - 2019-01-07
 ### Changed
 - Updated `hotels.oss.plugin.config` version to 1.2.2 (was 1.1.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.0.0] - TBD
 ### Changed
 - Updated `jdk` version to 1.8 (was 1.7).
-- Removed `cobertura-maven-plugin` as it's not compatible with JDK versions greater than 1.7.
+- Removed `cobertura-maven-plugin`, from reporting sections, as it's not compatible with JDK versions greater than 1.8.
 - Updated `maven-compiler-plugin` version to 3.8.0 (was 3.7.0).
 - Updated `jacoco-maven-plugin` version to 0.8.2 (was 0.8.1).
 - Added `maven-compiler-plugin` option in order to add constructor parameter's names to compiled classes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.0.0] - TBD
 ### Changed
-- Updated `jdk` version to 1.8 (was 1.7)..
+- Updated `jdk` version to 1.8 (was 1.7).
+- Removed `cobertura-maven-plugin` as it's not compatible with jdk version grater than 1.8.
 - Updated `maven-compiler-plugin` version to 3.8.0 (was 3.7.0).
-- Modified `cobertura-maven-plugin` configuration in order to be not inherited by submodules.
 - Updated `jacoco-maven-plugin` version to 0.8.2 (was 0.8.1).
 - Added `maven-compiler-plugin` option in order to add constructor parameter's names to compiled classes.
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 
   <properties>
     <buildnumber.maven.plugin.version>1.4</buildnumber.maven.plugin.version>
+    <cobertura.version>2.1.1</cobertura.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>
     <failsafe.maven.plugin.version>2.22.0</failsafe.maven.plugin.version>
     <findbugs.maven.plugin.version>3.0.5</findbugs.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.hotels</groupId>
   <artifactId>hotels-oss-parent</artifactId>
-  <version>2.3.6-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <description>Parent POM for Hotels.com open source projects</description>
   <packaging>pom</packaging>
   <url>https://github.com/HotelsDotCom/hotels-oss-parent</url>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,6 @@
 
   <properties>
     <buildnumber.maven.plugin.version>1.4</buildnumber.maven.plugin.version>
-    <cobertura.version>2.1.1</cobertura.version>
-    <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>
     <failsafe.maven.plugin.version>2.22.0</failsafe.maven.plugin.version>
     <findbugs.maven.plugin.version>3.0.5</findbugs.maven.plugin.version>
@@ -131,28 +129,6 @@
             </manifestEntries>
           </archive>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>${cobertura.maven.plugin.version}</version>
-        <inherited>false</inherited>
-        <configuration>
-          <encoding>${project.build.sourceEncoding}</encoding>
-          <aggregate>true</aggregate>
-          <formats>
-            <format>xml</format>
-            <format>html</format>
-          </formats>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>clean</goal>
-              <goal>cobertura</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
@@ -517,21 +493,6 @@
         <version>${maven.javadoc.plugin.version}</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>${cobertura.maven.plugin.version}</version>
-        <inherited>false</inherited>
-        <configuration>
-          <encoding>${project.build.sourceEncoding}</encoding>
-          <aggregate>true</aggregate>
-          <formats>
-            <format>html</format>
-            <format>xml</format>
-          </formats>
-          <check />
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,11 @@
     <failsafe.maven.plugin.version>2.22.0</failsafe.maven.plugin.version>
     <findbugs.maven.plugin.version>3.0.5</findbugs.maven.plugin.version>
     <hotels.oss.plugin.config.version>1.2.2</hotels.oss.plugin.config.version>
-    <jacoco.version>0.8.1</jacoco.version>
-    <jdk.version>1.7</jdk.version>
+    <jacoco.version>0.8.2</jacoco.version>
+    <jdk.version>1.8</jdk.version>
     <license.maven.plugin.version>3.0</license.maven.plugin.version>
     <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
-    <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+    <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
     <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
     <maven.jar.plugin.version>3.1.0</maven.jar.plugin.version>
     <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
@@ -114,6 +114,7 @@
           <target>${jdk.version}</target>
           <encoding>${project.build.sourceEncoding}</encoding>
           <showWarnings>true</showWarnings>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>
@@ -135,6 +136,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>${cobertura.maven.plugin.version}</version>
+        <inherited>false</inherited>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
           <aggregate>true</aggregate>
@@ -521,6 +523,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>${cobertura.maven.plugin.version}</version>
+        <inherited>false</inherited>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
           <aggregate>true</aggregate>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
   <properties>
     <buildnumber.maven.plugin.version>1.4</buildnumber.maven.plugin.version>
     <cobertura.version>2.1.1</cobertura.version>
+    <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>
     <failsafe.maven.plugin.version>2.22.0</failsafe.maven.plugin.version>
     <findbugs.maven.plugin.version>3.0.5</findbugs.maven.plugin.version>
@@ -130,6 +131,27 @@
             </manifestEntries>
           </archive>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>${cobertura.maven.plugin.version}</version>
+        <configuration>
+          <encoding>${project.build.sourceEncoding}</encoding>
+          <aggregate>true</aggregate>
+          <formats>
+            <format>xml</format>
+            <format>html</format>
+          </formats>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>clean</goal>
+              <goal>cobertura</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
- Modified `cobertura-maven-plugin` configuration in order to be not inherited by submodules.
- Updated `jacoco-maven-plugin` version to 0.8.2 (was 0.8.1)..
- Updated `maven-compiler-plugin` version to 3.8.0 (was 3.7.0)..
- Added `maven-compiler-plugin` option in order to add constructor parameter's names to compiled classes.
- Updated `jdk` version to 1.8 (was 1.7)..