### PR TITLE
Site plugin management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [TBD] - TBD
+
+### Changed
+- Added `maven-site-plugin` to `pluginManagement` section.
+
 ## [3.0.0] - 2019-01-24
 ### Changed
 - Updated `jdk` version to 1.8 (was 1.7).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [TBD] - TBD
-
 ### Changed
 - Added `maven-site-plugin` to `pluginManagement` section.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [TBD] - TBD
+## [3.0.1] - 2019-01-24
 ### Changed
 - Added `maven-site-plugin` to `pluginManagement` section.
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.hotels</groupId>
@@ -303,6 +304,11 @@
 
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${maven.site.plugin.version}</version>
+        </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>failsafe-maven-plugin</artifactId>


### PR DESCRIPTION
According to the Maven docs at https://maven.apache.org/plugins/maven-site-plugin/plugin-info.html (scroll down to "Usage") it seems like the recommend you put the maven-site-plugin in the pluginManagement section so you can control the default version used and then also declare it in the build/reporting section of your pom (we have it in the latter). This fixes some issues where, without this, Maven seems to download a different version of the plugin (probably an older one) that then causes classpath clashes with other plugins etc. Doing it this way gives us more options for controlling the version of the plugin in use.