### PR TITLE
Making findbugs-maven-plugin reporting optional for child modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.0.0] - TBD
+## [4.0.0] - 2019-01-28
 ### Removed
 - Removed `findbugs-maven-plugin` from reporting as it's not compatible with JDK versions greater than 1.8.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.1.0] - TBD
-### Changed
-- Made `findbugs-maven-plugin` optional for child modules as it is not compatible with JDK greater than 1.8.
+## [4.0.0] - TBD
+### Removed
+- Removed `findbugs-maven-plugin` from reporting as it's not compatible with JDK versions greater than 1.8.
 
 ## [3.0.1] - 2019-01-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.0] - TBD
+### Changed
+- Made `findbugs-maven-plugin` optional for child modules as it is not compatible with JDK greater than 1.8.
+
 ## [3.0.1] - 2019-01-24
 ### Changed
 - Added `maven-site-plugin` to `pluginManagement` section.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.hotels</groupId>
   <artifactId>hotels-oss-parent</artifactId>
-  <version>3.0.2-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <description>Parent POM for Hotels.com open source projects</description>
   <packaging>pom</packaging>
   <url>https://github.com/HotelsDotCom/hotels-oss-parent</url>
@@ -521,15 +521,6 @@
         <version>${maven.javadoc.plugin.version}</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>${findbugs.maven.plugin.version}</version>
-        <inherited>false</inherited>
-        <configuration>
-          <excludeFilterFile>file://${project.build.directory}/plugin-config/findbugs/hotels-findbugs-exclude.xml</excludeFilterFile>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -527,6 +527,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>${findbugs.maven.plugin.version}</version>
+        <inherited>false</inherited>
         <configuration>
           <excludeFilterFile>file://${project.build.directory}/plugin-config/findbugs/hotels-findbugs-exclude.xml</excludeFilterFile>
         </configuration>


### PR DESCRIPTION
Made `findbugs-maven-plugin` optional for child modules as it is not compatible with JDK greater than 1.8.