### PR TITLE
Dependency update checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Updated `jdk` version to 1.8 (was 1.7).
 - Updated `maven-checkstyle-plugin` version to 3.1.0 (was 3.0.0).
-- Updated `maven-compiler-plugin` version to 3.8.1 (was 3.8.1).
+- Updated `maven-compiler-plugin` version to 3.8.1 (was 3.8.0).
 - Updated `maven-jar-plugin` version to 3.1.2 (was 3.1.0).
 - Updated `maven-javadoc-plugin` version to 3.1.0 (was 3.0.1).
 - Updated `maven-jxr-plugin` version to 3.0.0 (was 2.5).
 - Updated `maven-pmd-plugin` version to 3.12.0 (was 3.10.0).
-- Updated `maven-source-plugin` version to 3.1.0 (was 3.0.1).
 - Updated `maven-source-plugin` version to 3.1.0 (was 3.0.1).
 - Updated `jacoco-surefire-plugin` version to 2.22.2 (was 2.22.0).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.1] - TBD
+### Added
+- Added a check-for-updates profile which verifies if there are dependencies that can be upgraded.
+### Changed
+- Updated `jdk` version to 1.8 (was 1.7).
+- Updated `maven-checkstyle-plugin` version to 3.1.0 (was 3.0.0).
+- Updated `maven-compiler-plugin` version to 3.8.1 (was 3.8.1).
+- Updated `maven-jar-plugin` version to 3.1.2 (was 3.1.0).
+- Updated `maven-javadoc-plugin` version to 3.1.0 (was 3.0.1).
+- Updated `maven-jxr-plugin` version to 3.0.0 (was 2.5).
+- Updated `maven-pmd-plugin` version to 3.12.0 (was 3.10.0).
+- Updated `maven-source-plugin` version to 3.1.0 (was 3.0.1).
+- Updated `maven-source-plugin` version to 3.1.0 (was 3.0.1).
+- Updated `jacoco-surefire-plugin` version to 2.22.2 (was 2.22.0).
+
 ## [3.0.0] - 2019-01-24
 ### Changed
 - Updated `jdk` version to 1.8 (was 1.7).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.0.2] - TBD
+## [4.1.0] - TBD
 ### Added
 - Added a check-for-updates profile which verifies if there are dependencies that can be upgraded.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added a check-for-updates profile which verifies if there are dependencies that can be upgraded.
 ### Changed
-- Updated `jdk` version to 1.8 (was 1.7).
 - Updated `maven-checkstyle-plugin` version to 3.1.0 (was 3.0.0).
 - Updated `maven-compiler-plugin` version to 3.8.1 (was 3.8.0).
 - Updated `maven-jar-plugin` version to 3.1.2 (was 3.1.0).
@@ -16,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated `maven-jxr-plugin` version to 3.0.0 (was 2.5).
 - Updated `maven-pmd-plugin` version to 3.12.0 (was 3.10.0).
 - Updated `maven-source-plugin` version to 3.1.0 (was 3.0.1).
-- Updated `jacoco-surefire-plugin` version to 2.22.2 (was 2.22.0).
+- Updated `maven-surefire-plugin` version to 2.22.2 (was 2.22.0).
+- Updated `jacoco-maven-plugin` version to 0.8.4 (was 0.8.2).
 
 ## [4.0.1] - 2019-03-01
 ### Changed

--- a/config/maven/updateRules.xml
+++ b/config/maven/updateRules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" comparisonMethod="maven" xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+    <ignoreVersions>
+        <!-- Ignore Alpha's, Beta's, release candidates and milestones -->
+        <ignoreVersion type="regex">(?i).*Alpha(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*a(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*Beta(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*-B(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*RC(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*CR(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*M(?:-?\d+)?</ignoreVersion>
+    </ignoreVersions>
+    <rules>
+    </rules>
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.hotels</groupId>
   <artifactId>hotels-oss-parent</artifactId>
-  <version>4.0.2-SNAPSHOT</version>
+  <version>4.1.0-SNAPSHOT</version>
   <description>Parent POM for Hotels.com open source projects</description>
   <packaging>pom</packaging>
   <url>https://github.com/HotelsDotCom/hotels-oss-parent</url>
@@ -59,9 +59,9 @@
     <maven.source.plugin.version>3.1.0</maven.source.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
-    <maven.update.checker.version>2.7</maven.update.checker.version>
+    <maven.versions.plugin.version>2.7</maven.versions.plugin.version>
     <maven.enforcer.plugin.version>3.0.0-M2</maven.enforcer.plugin.version>
-    <maven.required.version>3.3.9</maven.required.version>
+    <maven.required.version>[3.3.9,)</maven.required.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
@@ -380,9 +380,9 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>${maven.update.checker.version}</version>
+          <version>${maven.versions.plugin.version}</version>
           <configuration>
-            <rulesUri>file:///${project.basedir}/config/maven/updateRules.xml</rulesUri>
+            <rulesUri>file:///${project.basedir}/src/main/resources/versions-plugin-rules.xml</rulesUri>
           </configuration>
           <executions>
             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -45,22 +45,25 @@
     <failsafe.maven.plugin.version>2.22.0</failsafe.maven.plugin.version>
     <findbugs.maven.plugin.version>3.0.5</findbugs.maven.plugin.version>
     <hotels.oss.plugin.config.version>1.2.2</hotels.oss.plugin.config.version>
-    <jacoco.version>0.8.2</jacoco.version>
+    <jacoco.version>0.8.4</jacoco.version>
     <jdk.version>1.8</jdk.version>
     <license.maven.plugin.version>3.0</license.maven.plugin.version>
-    <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
-    <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
+    <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
+    <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
-    <maven.jar.plugin.version>3.1.0</maven.jar.plugin.version>
-    <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
-    <maven.jxr.plugin.version>2.5</maven.jxr.plugin.version>
-    <maven.pmd.plugin.version>3.10.0</maven.pmd.plugin.version>
+    <maven.jar.plugin.version>3.1.2</maven.jar.plugin.version>
+    <maven.javadoc.plugin.version>3.1.0</maven.javadoc.plugin.version>
+    <maven.jxr.plugin.version>3.0.0</maven.jxr.plugin.version>
+    <maven.pmd.plugin.version>3.12.0</maven.pmd.plugin.version>
     <maven.project.info.reports.plugin.version>3.0.0</maven.project.info.reports.plugin.version>
-    <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
+    <maven.source.plugin.version>3.1.0</maven.source.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
+    <maven.update.checker.version>2.7</maven.update.checker.version>
+    <maven.enforcer.plugin.version>3.0.0-M2</maven.enforcer.plugin.version>
+    <maven.required.version>3.3.9</maven.required.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
     <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
     <nexus.staging.maven.plugin.version>1.6.8</nexus.staging.maven.plugin.version>
@@ -299,6 +302,26 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven.enforcer.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>${maven.required.version}</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -365,6 +388,23 @@
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>${maven.update.checker.version}</version>
+          <configuration>
+            <rulesUri>file:///${project.basedir}/config/maven/updateRules.xml</rulesUri>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>compile</phase>
+              <goals>
+                <goal>display-dependency-updates</goal>
+                <goal>display-plugin-updates</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -461,6 +501,18 @@
             <groupId>org.eluder.coveralls</groupId>
             <artifactId>coveralls-maven-plugin</artifactId>
             <version>${coveralls.maven.plugin.version}</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>check-for-updates</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>versions-maven-plugin</artifactId>
+            <inherited>false</inherited>
           </plugin>
         </plugins>
       </build>

--- a/src/main/resources/versions-plugin-rules.xml
+++ b/src/main/resources/versions-plugin-rules.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2015-2019 Expedia, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <ruleset xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" comparisonMethod="maven" xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
     <ignoreVersions>
         <!-- Ignore Alpha's, Beta's, release candidates and milestones -->


### PR DESCRIPTION
In order to keep the dependencies up-to-date, a new maven profile: `check-for-updates` has been created.
This profile will highlight the dependencies that can be updated and the new versions to be adopted.

I took the occasion to update the existing dependencies as highlighted from the profile