### PR TITLE
Renamed `travis` profile to `coveralls`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ cache:
   directories:
     - ~/.m2/repository
 install:
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true --quiet --batch-mode --show-version --activate-profiles travis
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true --quiet --batch-mode --show-version
 script:
-  - mvn package --batch-mode --show-version --activate-profiles travis
+  - mvn package --batch-mode --show-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [5.0.0] - TBD
+## [5.0.0] - 2020-02-10
 ### Changed
 - Renamed `travis` profile to `coveralls`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.0.0] - TBD
+### Changed
+- Renamed `travis` profile to `coveralls`.
+
 ## [4.3.1] - 2020-02-06
 ### Changed
 - Effectively the same as 4.3.0, just re-released due to Sonatype issues.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.hotels</groupId>
   <artifactId>hotels-oss-parent</artifactId>
-  <version>4.3.2-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <description>Parent POM for Hotels.com open source projects</description>
   <packaging>pom</packaging>
   <url>https://github.com/HotelsDotCom/hotels-oss-parent</url>
@@ -543,7 +543,7 @@
       </build>
     </profile>
     <profile>
-      <id>travis</id>
+      <id>coveralls</id>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
Now that we're starting to use GH actions in downstream projects it makes more sense to give this profile a more descriptive name.