### PR TITLE
Remove Cobertura

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.0.0] - TBD
+### Removed
+- `cobertura` plugin.
+
 ## [5.0.0] - 2020-02-10
 ### Changed
 - Renamed `travis` profile to `coveralls`.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Hotels OSS Parent
 # Legal
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
-Copyright 2015-2019 Expedia, Inc.
+Copyright 2015-2020 Expedia, Inc.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.hotels</groupId>
   <artifactId>hotels-oss-parent</artifactId>
-  <version>5.0.1-SNAPSHOT</version>
+  <version>6.0.0-SNAPSHOT</version>
   <description>Parent POM for Hotels.com open source projects</description>
   <packaging>pom</packaging>
   <url>https://github.com/HotelsDotCom/hotels-oss-parent</url>
@@ -39,8 +39,6 @@
 
   <properties>
     <buildnumber.maven.plugin.version>1.4</buildnumber.maven.plugin.version>
-    <cobertura.version>2.1.1</cobertura.version>
-    <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>
     <failsafe.maven.plugin.version>2.22.0</failsafe.maven.plugin.version>
     <findbugs.maven.plugin.version>3.0.5</findbugs.maven.plugin.version>
@@ -161,27 +159,6 @@
             </manifestEntries>
           </archive>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>${cobertura.maven.plugin.version}</version>
-        <configuration>
-          <encoding>${project.build.sourceEncoding}</encoding>
-          <aggregate>true</aggregate>
-          <formats>
-            <format>xml</format>
-            <format>html</format>
-          </formats>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>clean</goal>
-              <goal>cobertura</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
The invocation of Cobertura during `clean` can cause issues on Java 11, we've moved to `jacoco` for coverage so let's just remove this.